### PR TITLE
update: properly use pam_config from pillars

### DIFF
--- a/pam/update.sls
+++ b/pam/update.sls
@@ -1,4 +1,5 @@
 {% from "pam/map.jinja" import pam with context %}
+{% set pam_config = salt['pillar.get']('pam:pam_config', pam.pam_config) %}
 
 {% if grains.os_family == 'Debian' %}
 pam-auth-update:
@@ -6,7 +7,7 @@ pam-auth-update:
     - name: DEBIAN_FRONTEND=noninteractive pam-auth-update --force
 {% endif %}
 
-{% for file_name, config in pam['pam_config'].items() %}
+{% for file_name, config in pam_config.items() %}
 /usr/share/pam-configs/{{ file_name }}:
   file.managed:
     - source: salt://pam/files/pam-config.jinja


### PR DESCRIPTION
pillar.example shows pam:pam_config
Code only really used pam:lookup:pam_config

Now properly uses pam:pam_config if available.