### PR TITLE
Remove seen file before update pam

### DIFF
--- a/pam/update.sls
+++ b/pam/update.sls
@@ -2,6 +2,10 @@
 
 {% if grains.os_family == 'Debian' %}
 pam-auth-update:
+  module.run:
+    - name: file.remove
+    - path: /var/lib/pam/seen
+
   cmd.run:
     - name: DEBIAN_FRONTEND=noninteractive pam-auth-update --force
 {% endif %}


### PR DESCRIPTION
Hello,

I need to remove the "seen" files before pam-auth-update for Debian.
Without that the configuration is not refresh.